### PR TITLE
Increase payload cache size

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -27,7 +27,7 @@ static UPLINK_ID: Mutex<u16> = Mutex::new(0);
 static UPLINK_CONTEXT: LazyLock<Mutex<HashMap<u16, Vec<u8>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static PAYLOAD_CACHE: LazyLock<Mutex<Cache<PayloadCache>>> =
-    LazyLock::new(|| Mutex::new(Cache::new(64)));
+    LazyLock::new(|| Mutex::new(Cache::new(256)));
 
 // Handle LoRaWAN payload (non-proprietary).
 pub async fn handle_uplink(border_gateway: bool, pl: &gw::UplinkFrame) -> Result<()> {


### PR DESCRIPTION
## Summary
- bump payload cache size to 256

## Testing
- `cargo clippy --no-deps`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5fbcf9a88332af36f37eab8015f5