### PR TITLE
Add ATX-oriented routing scaffolding and metrics modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "signal-hook-tokio",
  "simple_logger",
  "syslog",
+ "thiserror 1.0.69",
  "tokio",
  "toml 0.9.4",
  "zeromq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@
   cmac = "0.7"
   aes = "0.8"
   chrono = { version = "0.4", default-features = false, features = ["clock"] }
+  thiserror = "1.0"
 
 [dev-dependencies]
   zeromq = "0.4"

--- a/src/ack_lite.rs
+++ b/src/ack_lite.rs
@@ -1,0 +1,69 @@
+use anyhow::{anyhow, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckLite {
+    pub child_relay_id: u8,
+    pub uplink_id: u16,
+    pub status: AckStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AckStatus {
+    Ok,
+    Failed,
+}
+
+impl AckLite {
+    pub const LEN: usize = 4;
+
+    pub fn encode(&self) -> [u8; Self::LEN] {
+        let mut buf = [0u8; Self::LEN];
+        buf[0] = self.child_relay_id;
+        buf[1..3].copy_from_slice(&self.uplink_id.to_be_bytes());
+        buf[3] = match self.status {
+            AckStatus::Ok => 1,
+            AckStatus::Failed => 0,
+        };
+        buf
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        if data.len() != Self::LEN {
+            return Err(anyhow!("invalid ack-lite length: {}", data.len()));
+        }
+        let uplink_id = u16::from_be_bytes([data[1], data[2]]);
+        let status = match data[3] {
+            0 => AckStatus::Failed,
+            1 => AckStatus::Ok,
+            v => return Err(anyhow!("invalid ack-lite status: {}", v)),
+        };
+        Ok(Self {
+            child_relay_id: data[0],
+            uplink_id,
+            status,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let ack = AckLite {
+            child_relay_id: 0x0A,
+            uplink_id: 0x1234,
+            status: AckStatus::Ok,
+        };
+
+        let buf = ack.encode();
+        let decoded = AckLite::decode(&buf).unwrap();
+        assert_eq!(ack, decoded);
+    }
+
+    #[test]
+    fn decode_rejects_invalid_len() {
+        assert!(AckLite::decode(&[1, 2, 3]).is_err());
+    }
+}

--- a/src/airtime.rs
+++ b/src/airtime.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+/// Description of a LoRa physical layer profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LoraPhy {
+    pub sf: u8,
+    pub cr: (u8, u8),
+    pub bw_hz: u32,
+}
+
+/// Key used for airtime cache lookups.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AirtimeKey {
+    pub phy: LoraPhy,
+    pub payload_len: usize,
+}
+
+static AIRTIME_CACHE: LazyLock<Mutex<HashMap<AirtimeKey, u32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Returns the airtime (time-on-air) in microseconds for the given key.
+///
+/// The computation follows the LoRa modulation time-on-air formula as
+/// documented in the Semtech datasheets. Results are cached to avoid
+/// repeatedly evaluating the expensive floating point expressions.
+pub fn toa_us(key: &AirtimeKey) -> u32 {
+    if let Some(v) = AIRTIME_CACHE.lock().unwrap().get(key) {
+        return *v;
+    }
+
+    let toa = compute_toa_us(key);
+    AIRTIME_CACHE
+        .lock()
+        .unwrap()
+        .entry(key.clone())
+        .or_insert(toa);
+    toa
+}
+
+fn compute_toa_us(key: &AirtimeKey) -> u32 {
+    let sf = key.phy.sf as f32;
+    let bw = key.phy.bw_hz as f32;
+    let (cr_num, cr_den) = key.phy.cr;
+    let cr = (cr_den.saturating_sub(cr_num)) as f32; // CR = denominator - numerator, e.g. 4/5 -> 1
+
+    // Low data-rate optimization as defined by the LoRa spec.
+    let low_dr_opt = if (key.phy.bw_hz == 125_000 && key.phy.sf >= 11)
+        || (key.phy.bw_hz == 62_500 && key.phy.sf >= 10)
+    {
+        1.0
+    } else {
+        0.0
+    };
+
+    let symbol_duration = 2f32.powi(sf as i32) / bw; // seconds
+    let preamble_symb = 8.0_f32 + 4.25; // default preamble of 8 symbols + 4.25
+
+    let payload_symb_nb = {
+        let payload = key.payload_len as f32;
+        let numerator = 8.0 * payload - 4.0 * sf + 28.0 + 16.0 - 20.0 * low_dr_opt;
+        let denominator = 4.0 * (sf - 2.0 * low_dr_opt);
+        let ceil = (numerator / denominator).ceil().max(0.0);
+        8.0_f32.max(ceil * (cr + 4.0))
+    };
+
+    let total_time_s = (preamble_symb + payload_symb_nb) * symbol_duration;
+    (total_time_s * 1_000_000.0) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toa_cache() {
+        let phy = LoraPhy {
+            sf: 12,
+            cr: (4, 8),
+            bw_hz: 812_000,
+        };
+        let key = AirtimeKey {
+            phy,
+            payload_len: 47,
+        };
+
+        let v1 = toa_us(&key);
+        let v2 = toa_us(&key);
+        assert_eq!(v1, v2);
+        assert!(v1 > 0);
+    }
+
+    #[test]
+    fn test_toa_changes_with_payload() {
+        let phy = LoraPhy {
+            sf: 7,
+            cr: (4, 5),
+            bw_hz: 125_000,
+        };
+        let short = AirtimeKey {
+            phy,
+            payload_len: 1,
+        };
+        let long = AirtimeKey {
+            phy,
+            payload_len: 50,
+        };
+
+        assert!(toa_us(&long) > toa_us(&short));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,11 @@ pub struct Configuration {
     pub mappings: Mappings,
     pub events: Events,
     pub commands: Commands,
+    pub routing: RoutingConfig,
+    pub scheduler: SchedulerConfig,
+    pub ack_lite: AckLiteConfig,
+    pub jit: JitConfig,
+    pub phy: PhyConfig,
 }
 
 impl Configuration {
@@ -190,6 +195,121 @@ pub struct EventsSet {
 #[serde(default)]
 pub struct Commands {
     pub commands: HashMap<String, Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(default)]
+pub struct RoutingConfig {
+    pub metric: String,
+    pub hysteresis_ratio: f32,
+    pub trigger_delta_atx: f32,
+    pub trickle_min_ms: u32,
+    pub trickle_max_ms: u32,
+}
+
+impl RoutingConfig {
+    pub fn metric_is_atx(&self) -> bool {
+        self.metric.to_ascii_lowercase() == "atx"
+    }
+}
+
+impl Default for RoutingConfig {
+    fn default() -> Self {
+        Self {
+            metric: "etx".to_string(),
+            hysteresis_ratio: 0.15,
+            trigger_delta_atx: 0.1,
+            trickle_min_ms: 2_000,
+            trickle_max_ms: 120_000,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(default)]
+pub struct SchedulerConfig {
+    pub mode: String,
+    pub quantum_scale: u32,
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            mode: "fifo".to_string(),
+            quantum_scale: 50_000,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(default)]
+pub struct AckLiteConfig {
+    pub enabled: bool,
+    pub retry: u8,
+    pub timeout_ms: u32,
+}
+
+impl Default for AckLiteConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            retry: 0,
+            timeout_ms: 120,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(default)]
+pub struct JitConfig {
+    pub post_tx_rx_guard_ms: u32,
+}
+
+impl Default for JitConfig {
+    fn default() -> Self {
+        Self {
+            post_tx_rx_guard_ms: 10,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(default)]
+pub struct PhyConfig {
+    pub allowed: Vec<PhyCapability>,
+}
+
+impl Default for PhyConfig {
+    fn default() -> Self {
+        Self {
+            allowed: vec![PhyCapability {
+                sf: 12,
+                cr_numerator: 4,
+                cr_denominator: 8,
+                bw_hz: 812_000,
+            }],
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[serde(default)]
+pub struct PhyCapability {
+    pub sf: u8,
+    pub cr_numerator: u8,
+    pub cr_denominator: u8,
+    pub bw_hz: u32,
+}
+
+impl Default for PhyCapability {
+    fn default() -> Self {
+        Self {
+            sf: 12,
+            cr_numerator: 4,
+            cr_denominator: 8,
+            bw_hz: 812_000,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/jit_guard.rs
+++ b/src/jit_guard.rs
@@ -1,0 +1,99 @@
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy)]
+pub struct JitGuardCfg {
+    pub tx_start_delay_ms: u32,
+    pub tx_jit_delay_ms: u32,
+    pub post_tx_rx_guard_ms: u32,
+}
+
+impl Default for JitGuardCfg {
+    fn default() -> Self {
+        Self {
+            tx_start_delay_ms: 2,
+            tx_jit_delay_ms: 80,
+            post_tx_rx_guard_ms: 10,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScheduledTx {
+    pub start: Instant,
+    pub end: Instant,
+}
+
+#[derive(Debug)]
+pub struct JitGuard {
+    cfg: JitGuardCfg,
+    last_tx: Option<ScheduledTx>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ScheduleError {
+    #[error("tx scheduled too late")]
+    TooLate,
+    #[error("post tx guard violation")]
+    GuardViolation,
+}
+
+impl JitGuard {
+    pub fn new(cfg: JitGuardCfg) -> Self {
+        Self { cfg, last_tx: None }
+    }
+
+    pub fn schedule_tx(
+        &mut self,
+        now: Instant,
+        airtime_us: u32,
+    ) -> Result<ScheduledTx, ScheduleError> {
+        let start = now + Duration::from_millis(self.cfg.tx_start_delay_ms as u64);
+        let end = start + Duration::from_micros(airtime_us as u64);
+
+        if let Some(last) = &self.last_tx {
+            let guard = Duration::from_millis(self.cfg.post_tx_rx_guard_ms as u64);
+            if now < last.end + guard {
+                return Err(ScheduleError::GuardViolation);
+            }
+        }
+
+        self.last_tx = Some(ScheduledTx { start, end });
+        Ok(self.last_tx.clone().unwrap())
+    }
+
+    pub fn on_tx_done(&mut self, end: Instant) {
+        if let Some(last) = &mut self.last_tx {
+            last.end = end;
+        }
+    }
+
+    pub fn can_enter_rx(&self, now: Instant) -> bool {
+        match &self.last_tx {
+            None => true,
+            Some(last) => {
+                let guard = Duration::from_millis(self.cfg.post_tx_rx_guard_ms as u64);
+                now >= last.end + guard
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_blocks_back_to_back() {
+        let cfg = JitGuardCfg {
+            tx_start_delay_ms: 1,
+            tx_jit_delay_ms: 80,
+            post_tx_rx_guard_ms: 10,
+        };
+        let mut guard = JitGuard::new(cfg);
+        let now = Instant::now();
+        let _ = guard.schedule_tx(now, 1000).unwrap();
+        assert!(guard
+            .schedule_tx(now + Duration::from_millis(5), 1000)
+            .is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 #[macro_use]
 extern crate anyhow;
 
+pub mod ack_lite;
 pub mod aes128;
+pub mod airtime;
 pub mod backend;
 pub mod cache;
 pub mod cmd;
@@ -9,7 +11,13 @@ pub mod commands;
 pub mod config;
 pub mod events;
 pub mod helpers;
+pub mod jit_guard;
+pub mod link_estimator;
 pub mod logging;
 pub mod mesh;
 pub mod packets;
+pub mod phy_profile;
 pub mod proxy;
+pub mod routing;
+pub mod scheduler;
+pub mod telemetry;

--- a/src/link_estimator.rs
+++ b/src/link_estimator.rs
@@ -1,0 +1,190 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use crate::airtime::{toa_us, AirtimeKey, LoraPhy};
+
+/// Snapshot of the current link statistics for a neighbour.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LinkStats {
+    pub prr_in: f32,
+    pub prr_out: f32,
+    pub etx: f32,
+    pub toa_us: u32,
+    pub atx: f32,
+}
+
+impl Default for LinkStats {
+    fn default() -> Self {
+        Self {
+            prr_in: 1.0,
+            prr_out: 1.0,
+            etx: 1.0,
+            toa_us: 0,
+            atx: 1.0,
+        }
+    }
+}
+
+/// Trait representing a link estimator implementation.
+pub trait LinkEstimator<N>
+where
+    N: Eq + Hash + Copy,
+{
+    fn observe_tx(&mut self, nhop: N, uplink_id: u16);
+    fn observe_ack(&mut self, nhop: N, uplink_id: u16, ok: bool);
+    fn snapshot(&self, nhop: N, payload_len: usize, phy: &LoraPhy) -> LinkStats;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LinkEstimatorCfg {
+    pub ewma_alpha: f32,
+    pub min_prr: f32,
+}
+
+impl Default for LinkEstimatorCfg {
+    fn default() -> Self {
+        Self {
+            ewma_alpha: 0.25,
+            min_prr: 0.05,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EwmaEntry {
+    prr_in: f32,
+    prr_out: f32,
+    tx_total: u32,
+    ack_total: u32,
+}
+
+impl Default for EwmaEntry {
+    fn default() -> Self {
+        Self {
+            prr_in: 1.0,
+            prr_out: 1.0,
+            tx_total: 0,
+            ack_total: 0,
+        }
+    }
+}
+
+/// Basic EWMA based link estimator.
+pub struct EwmaLinkEstimator<N>
+where
+    N: Eq + Hash + Copy,
+{
+    cfg: LinkEstimatorCfg,
+    entries: HashMap<N, EwmaEntry>,
+}
+
+impl<N> EwmaLinkEstimator<N>
+where
+    N: Eq + Hash + Copy,
+{
+    pub fn new(cfg: LinkEstimatorCfg) -> Self {
+        Self {
+            cfg,
+            entries: HashMap::new(),
+        }
+    }
+
+    fn entry_mut(&mut self, nhop: N) -> &mut EwmaEntry {
+        self.entries.entry(nhop).or_default()
+    }
+
+    fn entry(&self, nhop: N) -> EwmaEntry {
+        self.entries.get(&nhop).cloned().unwrap_or_default()
+    }
+}
+
+impl<N> LinkEstimator<N> for EwmaLinkEstimator<N>
+where
+    N: Eq + Hash + Copy,
+{
+    fn observe_tx(&mut self, nhop: N, _uplink_id: u16) {
+        let alpha = self.cfg.ewma_alpha;
+        let entry = self.entry_mut(nhop);
+        entry.tx_total = entry.tx_total.saturating_add(1);
+        entry.prr_out = (1.0 - alpha) * entry.prr_out;
+    }
+
+    fn observe_ack(&mut self, nhop: N, _uplink_id: u16, ok: bool) {
+        let alpha = self.cfg.ewma_alpha;
+        let entry = self.entry_mut(nhop);
+        entry.ack_total = entry.ack_total.saturating_add(1);
+        if ok {
+            entry.prr_out = (1.0 - alpha) * entry.prr_out + alpha;
+            entry.prr_in = (1.0 - alpha) * entry.prr_in + alpha;
+        } else {
+            entry.prr_out *= 1.0 - alpha;
+        }
+    }
+
+    fn snapshot(&self, nhop: N, payload_len: usize, phy: &LoraPhy) -> LinkStats {
+        let entry = self.entry(nhop);
+        let prr_in = entry.prr_in.max(self.cfg.min_prr);
+        let prr_out = entry.prr_out.max(self.cfg.min_prr);
+        let etx = 1.0 / (prr_in * prr_out);
+        let toa_us = toa_us(&AirtimeKey {
+            phy: *phy,
+            payload_len,
+        });
+        let atx = etx * (toa_us as f32 / 1_000_000.0);
+
+        LinkStats {
+            prr_in,
+            prr_out,
+            etx,
+            toa_us,
+            atx,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ewma_converges() {
+        let phy = LoraPhy {
+            sf: 12,
+            cr: (4, 8),
+            bw_hz: 812_000,
+        };
+        let mut estimator: EwmaLinkEstimator<u8> = EwmaLinkEstimator::new(LinkEstimatorCfg {
+            ewma_alpha: 0.5,
+            min_prr: 0.01,
+        });
+
+        for _ in 0..10 {
+            estimator.observe_tx(1, 1);
+            estimator.observe_ack(1, 1, true);
+        }
+
+        let stats = estimator.snapshot(1, 30, &phy);
+        assert!(stats.prr_in > 0.5);
+        assert!(stats.prr_out > 0.5);
+        assert!(stats.etx <= 4.0);
+        assert!(stats.atx > 0.0);
+    }
+
+    #[test]
+    fn snapshot_uses_min_prr() {
+        let phy = LoraPhy {
+            sf: 12,
+            cr: (4, 8),
+            bw_hz: 812_000,
+        };
+        let estimator: EwmaLinkEstimator<u8> = EwmaLinkEstimator::new(LinkEstimatorCfg {
+            ewma_alpha: 0.5,
+            min_prr: 0.2,
+        });
+
+        let stats = estimator.snapshot(1, 30, &phy);
+        assert_eq!(stats.prr_in, 1.0);
+        assert_eq!(stats.prr_out, 1.0);
+        assert!(stats.etx >= 1.0);
+    }
+}

--- a/src/phy_profile.rs
+++ b/src/phy_profile.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
+use crate::airtime::{toa_us, AirtimeKey, LoraPhy};
+
+#[derive(Debug, Clone)]
+pub struct PhyProfile {
+    pub allowed: Vec<LoraPhy>,
+}
+
+impl Default for PhyProfile {
+    fn default() -> Self {
+        Self {
+            allowed: vec![LoraPhy {
+                sf: 12,
+                cr: (4, 8),
+                bw_hz: 812_000,
+            }],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProbeResult {
+    pub phy: LoraPhy,
+    pub success: bool,
+    pub timestamp: Instant,
+}
+
+#[derive(Debug)]
+pub struct SfProbeCache {
+    entries: HashMap<(u32, LoraPhy), ProbeResult>,
+}
+
+impl SfProbeCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn update(&mut self, relay: u32, phy: LoraPhy, success: bool) {
+        self.entries.insert(
+            (relay, phy),
+            ProbeResult {
+                phy,
+                success,
+                timestamp: Instant::now(),
+            },
+        );
+    }
+
+    pub fn best_for(&self, relay: u32, payload_len: usize, profile: &PhyProfile) -> LoraPhy {
+        let mut best = profile.allowed.first().copied().unwrap_or(LoraPhy {
+            sf: 12,
+            cr: (4, 8),
+            bw_hz: 812_000,
+        });
+        let mut best_cost = f32::MAX;
+
+        for phy in &profile.allowed {
+            if let Some(res) = self.entries.get(&(relay, *phy)) {
+                if !res.success {
+                    continue;
+                }
+            }
+
+            let key = AirtimeKey {
+                phy: *phy,
+                payload_len,
+            };
+            let toa = toa_us(&key) as f32;
+            if toa < best_cost {
+                best_cost = toa;
+                best = *phy;
+            }
+        }
+
+        best
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chooses_fastest_phy() {
+        let profile = PhyProfile {
+            allowed: vec![
+                LoraPhy {
+                    sf: 12,
+                    cr: (4, 8),
+                    bw_hz: 812_000,
+                },
+                LoraPhy {
+                    sf: 7,
+                    cr: (4, 5),
+                    bw_hz: 812_000,
+                },
+            ],
+        };
+        let mut cache = SfProbeCache::new();
+        cache.update(1, profile.allowed[0], true);
+        cache.update(1, profile.allowed[1], true);
+
+        let best = cache.best_for(1, 30, &profile);
+        assert_eq!(best.sf, 7);
+    }
+}

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,237 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+use crate::airtime::LoraPhy;
+use crate::link_estimator::{LinkEstimator, LinkStats};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RouteEntry<N> {
+    pub parent: N,
+    pub cost_atx_path: f32,
+    pub depth: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RouteSelectorCfg {
+    pub hysteresis_ratio: f32,
+    pub trigger_delta_atx: f32,
+    pub trickle_min_ms: u32,
+    pub trickle_max_ms: u32,
+}
+
+impl Default for RouteSelectorCfg {
+    fn default() -> Self {
+        Self {
+            hysteresis_ratio: 0.15,
+            trigger_delta_atx: 0.1,
+            trickle_min_ms: 2_000,
+            trickle_max_ms: 120_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NeighborState {
+    advertised_cost: f32,
+    depth: u8,
+}
+
+pub trait RouteSelector<N>
+where
+    N: Eq + Hash + Copy,
+{
+    fn on_trickle_tick(&mut self, now: Instant);
+    fn on_beacon(&mut self, from: N, their_cost: f32, depth: u8, now: Instant);
+    fn choose_parent(&mut self) -> Option<RouteEntry<N>>;
+}
+
+/// Simple Trickle-inspired parent selector. It keeps track of neighbour
+/// announcements, uses ATX snapshots from the estimator and applies hysteresis
+/// to prevent rapid parent flapping.
+pub struct TrickleRouteSelector<N, E>
+where
+    N: Eq + Hash + Copy,
+    E: LinkEstimator<N>,
+{
+    cfg: RouteSelectorCfg,
+    estimator: E,
+    phy: LoraPhy,
+    payload_hint: usize,
+    current_parent: Option<RouteEntry<N>>,
+    neighbors: HashMap<N, NeighborState>,
+    trickle_interval: Duration,
+    next_tick: Instant,
+    last_recompute: Option<Instant>,
+}
+
+impl<N, E> TrickleRouteSelector<N, E>
+where
+    N: Eq + Hash + Copy,
+    E: LinkEstimator<N>,
+{
+    pub fn new(cfg: RouteSelectorCfg, estimator: E, phy: LoraPhy, payload_hint: usize) -> Self {
+        let start = Instant::now();
+        Self {
+            cfg,
+            estimator,
+            phy,
+            payload_hint,
+            current_parent: None,
+            neighbors: HashMap::new(),
+            trickle_interval: Duration::from_millis(cfg.trickle_min_ms as u64),
+            next_tick: start + Duration::from_millis(cfg.trickle_min_ms as u64),
+            last_recompute: None,
+        }
+    }
+
+    pub fn estimator_mut(&mut self) -> &mut E {
+        &mut self.estimator
+    }
+
+    pub fn estimator(&self) -> &E {
+        &self.estimator
+    }
+
+    fn recompute(&mut self, now: Instant) {
+        self.last_recompute = Some(now);
+        let mut best: Option<RouteEntry<N>> = None;
+
+        for (nhop, info) in &self.neighbors {
+            let stats = self.estimator.snapshot(*nhop, self.payload_hint, &self.phy);
+            let path_cost = info.advertised_cost + stats.atx;
+            let depth = info.depth.saturating_add(1);
+            let candidate = RouteEntry {
+                parent: *nhop,
+                cost_atx_path: path_cost,
+                depth,
+            };
+
+            match best {
+                None => best = Some(candidate),
+                Some(ref current) => {
+                    if should_replace(&self.cfg, current, &candidate, stats, self.current_parent) {
+                        best = Some(candidate);
+                    }
+                }
+            }
+        }
+
+        if let Some(best) = best {
+            if let Some(current) = self.current_parent {
+                if !parent_switch_allowed(&self.cfg, current, best) {
+                    return;
+                }
+            }
+            self.current_parent = Some(best);
+        }
+    }
+}
+
+fn parent_switch_allowed<N>(
+    cfg: &RouteSelectorCfg,
+    current: RouteEntry<N>,
+    new: RouteEntry<N>,
+) -> bool {
+    if (current.cost_atx_path - new.cost_atx_path).abs() <= cfg.trigger_delta_atx {
+        return false;
+    }
+    new.cost_atx_path <= current.cost_atx_path * (1.0 - cfg.hysteresis_ratio)
+}
+
+fn should_replace<N>(
+    cfg: &RouteSelectorCfg,
+    current: &RouteEntry<N>,
+    candidate: &RouteEntry<N>,
+    _stats: LinkStats,
+    current_parent: Option<RouteEntry<N>>,
+) -> bool
+where
+    N: Copy + PartialEq,
+{
+    if let Some(parent) = current_parent {
+        if parent.parent == candidate.parent {
+            return false;
+        }
+    }
+
+    if candidate.cost_atx_path + cfg.trigger_delta_atx < current.cost_atx_path {
+        return true;
+    }
+
+    if (candidate.cost_atx_path - current.cost_atx_path).abs() <= cfg.trigger_delta_atx {
+        return candidate.depth < current.depth;
+    }
+
+    candidate.cost_atx_path < current.cost_atx_path
+}
+
+impl<N, E> RouteSelector<N> for TrickleRouteSelector<N, E>
+where
+    N: Eq + Hash + Copy,
+    E: LinkEstimator<N>,
+{
+    fn on_trickle_tick(&mut self, now: Instant) {
+        if now < self.next_tick {
+            return;
+        }
+
+        self.recompute(now);
+
+        let new_interval = (self.trickle_interval.as_millis() * 2)
+            .min(self.cfg.trickle_max_ms as u128)
+            .max(self.cfg.trickle_min_ms as u128);
+        self.trickle_interval = Duration::from_millis(new_interval as u64);
+        self.next_tick = now + self.trickle_interval;
+    }
+
+    fn on_beacon(&mut self, from: N, their_cost: f32, depth: u8, now: Instant) {
+        self.neighbors.insert(
+            from,
+            NeighborState {
+                advertised_cost: their_cost,
+                depth,
+            },
+        );
+
+        let min_interval = Duration::from_millis(self.cfg.trickle_min_ms as u64);
+        self.trickle_interval = min_interval;
+        self.next_tick = now + min_interval;
+    }
+
+    fn choose_parent(&mut self) -> Option<RouteEntry<N>> {
+        if let Some(last) = self.last_recompute {
+            if last + Duration::from_millis(self.cfg.trickle_min_ms as u64) < Instant::now() {
+                self.recompute(Instant::now());
+            }
+        } else {
+            self.recompute(Instant::now());
+        }
+        self.current_parent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::link_estimator::{EwmaLinkEstimator, LinkEstimatorCfg};
+
+    #[test]
+    fn prefers_lower_atx() {
+        let phy = LoraPhy {
+            sf: 12,
+            cr: (4, 8),
+            bw_hz: 812_000,
+        };
+        let estimator: EwmaLinkEstimator<u8> = EwmaLinkEstimator::new(LinkEstimatorCfg::default());
+        let mut selector =
+            TrickleRouteSelector::new(RouteSelectorCfg::default(), estimator, phy, 30);
+
+        let now = Instant::now();
+        selector.on_beacon(1, 0.8, 2, now);
+        selector.on_beacon(2, 0.4, 3, now);
+
+        let parent = selector.choose_parent();
+        assert!(parent.is_some());
+    }
+}

--- a/src/scheduler/drr.rs
+++ b/src/scheduler/drr.rs
@@ -1,0 +1,157 @@
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct FrameEnvelope<T> {
+    pub frame: T,
+    pub airtime_us: u32,
+    pub enqueue_time: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub struct PerNextHopQueue<N, T>
+where
+    N: Eq + Hash + Copy,
+{
+    pub nhop: N,
+    pub deficit: i32,
+    pub quantum: i32,
+    pub queue: VecDeque<FrameEnvelope<T>>,
+}
+
+impl<N, T> PerNextHopQueue<N, T>
+where
+    N: Eq + Hash + Copy,
+{
+    fn new(nhop: N, quantum: i32) -> Self {
+        Self {
+            nhop,
+            deficit: 0,
+            quantum,
+            queue: VecDeque::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+pub struct DrrScheduler<N, T>
+where
+    N: Eq + Hash + Copy,
+{
+    quantum_scale: i32,
+    queues: Vec<PerNextHopQueue<N, T>>,
+    lookup: HashMap<N, usize>,
+    last_index: usize,
+    guard: Duration,
+}
+
+impl<N, T> DrrScheduler<N, T>
+where
+    N: Eq + Hash + Copy,
+{
+    pub fn new(quantum_scale: i32, guard: Duration) -> Self {
+        Self {
+            quantum_scale: quantum_scale.max(1),
+            queues: Vec::new(),
+            lookup: HashMap::new(),
+            last_index: 0,
+            guard,
+        }
+    }
+
+    fn ensure_queue(&mut self, nhop: N, airtime_us: u32) -> usize {
+        if let Some(idx) = self.lookup.get(&nhop) {
+            return *idx;
+        }
+
+        let quantum = compute_quantum(self.quantum_scale, airtime_us);
+        let idx = self.queues.len();
+        self.queues.push(PerNextHopQueue::new(nhop, quantum));
+        self.lookup.insert(nhop, idx);
+        idx
+    }
+
+    pub fn enqueue(&mut self, nhop: N, frame: T, airtime_us: u32, now: Instant) {
+        let idx = self.ensure_queue(nhop, airtime_us);
+        let q = &mut self.queues[idx];
+        let quantum = compute_quantum(self.quantum_scale, airtime_us);
+        if q.quantum != quantum {
+            q.quantum = quantum;
+        }
+        q.queue.push_back(FrameEnvelope {
+            frame,
+            airtime_us,
+            enqueue_time: now,
+        });
+    }
+
+    pub fn pick_next(&mut self, now: Instant) -> Option<(N, FrameEnvelope<T>)> {
+        if self.queues.is_empty() {
+            return None;
+        }
+
+        let mut scanned = 0;
+        let total = self.queues.len();
+
+        while scanned < total {
+            self.last_index %= self.queues.len();
+            let idx = self.last_index;
+            self.last_index = (self.last_index + 1) % self.queues.len();
+            scanned += 1;
+
+            let queue = &mut self.queues[idx];
+            if queue.is_empty() {
+                continue;
+            }
+
+            queue.deficit += queue.quantum;
+
+            if let Some(front) = queue.queue.front() {
+                let airtime = front.airtime_us as i32;
+                if queue.deficit < airtime {
+                    continue;
+                }
+
+                if now.duration_since(front.enqueue_time) < self.guard {
+                    continue;
+                }
+
+                queue.deficit -= airtime;
+                return queue.queue.pop_front().map(|f| (queue.nhop, f));
+            }
+        }
+
+        None
+    }
+}
+
+fn compute_quantum(scale: i32, airtime_us: u32) -> i32 {
+    let airtime = airtime_us.max(1) as i32;
+    (scale / airtime).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheduler_rotates() {
+        let mut sched: DrrScheduler<u8, u8> = DrrScheduler::new(50_000, Duration::from_millis(0));
+        let now = Instant::now();
+        sched.enqueue(1, 10, 400, now);
+        sched.enqueue(2, 11, 100, now);
+
+        let mut seen = Vec::new();
+        for i in 1..=10 {
+            if let Some((nhop, _)) = sched.pick_next(now + Duration::from_millis(i)) {
+                seen.push(nhop);
+            }
+        }
+        assert!(seen.contains(&1));
+        assert!(seen.contains(&2));
+    }
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,0 +1,1 @@
+pub mod drr;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,82 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct LinkTelemetry {
+    pub sf: Option<u8>,
+    pub cr: Option<String>,
+    pub bw_hz: Option<u32>,
+    pub toa_us: Option<u32>,
+    pub etx: Option<f32>,
+    pub atx_link: Option<f32>,
+    pub atx_path: Option<f32>,
+    pub parent_id: Option<String>,
+    pub ack_count: Option<u32>,
+    pub mesh_delay_ms: Option<u32>,
+    pub uplink_id: Option<u32>,
+}
+
+impl LinkTelemetry {
+    pub fn apply_to(&self, metadata: &mut BTreeMap<String, String>) {
+        if let Some(v) = self.sf {
+            metadata.insert("sf".to_string(), v.to_string());
+        }
+        if let Some(v) = &self.cr {
+            metadata.insert("cr".to_string(), v.clone());
+        }
+        if let Some(v) = self.bw_hz {
+            metadata.insert("bw_hz".to_string(), v.to_string());
+        }
+        if let Some(v) = self.toa_us {
+            metadata.insert("toa_us".to_string(), v.to_string());
+        }
+        if let Some(v) = self.etx {
+            metadata.insert("etx".to_string(), format!("{:.3}", v));
+        }
+        if let Some(v) = self.atx_link {
+            metadata.insert("atx_link".to_string(), format!("{:.3}", v));
+        }
+        if let Some(v) = self.atx_path {
+            metadata.insert("atx_path".to_string(), format!("{:.3}", v));
+        }
+        if let Some(v) = &self.parent_id {
+            metadata.insert("parent_id".to_string(), v.clone());
+        }
+        if let Some(v) = self.ack_count {
+            metadata.insert("ack_count".to_string(), v.to_string());
+        }
+        if let Some(v) = self.mesh_delay_ms {
+            metadata.insert("mesh_delay_ms".to_string(), v.to_string());
+        }
+        if let Some(v) = self.uplink_id {
+            metadata.insert("uplink_id".to_string(), v.to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_insertion() {
+        let mut meta = BTreeMap::new();
+        LinkTelemetry {
+            sf: Some(12),
+            cr: Some("4/8".into()),
+            bw_hz: Some(812_000),
+            toa_us: Some(425_000),
+            etx: Some(1.23),
+            atx_link: Some(0.52),
+            atx_path: Some(1.73),
+            parent_id: Some("0x03".into()),
+            ack_count: Some(4),
+            mesh_delay_ms: Some(600),
+            uplink_id: Some(417),
+        }
+        .apply_to(&mut meta);
+
+        assert_eq!(meta.get("sf"), Some(&"12".to_string()));
+        assert_eq!(meta.get("cr"), Some(&"4/8".to_string()));
+        assert_eq!(meta.get("parent_id"), Some(&"0x03".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary
- add airtime calculator, link estimator, and Trickle-based route selector primitives for ATX support
- introduce DRR per-next-hop scheduler, ACK-lite codec, JIT guard, and PHY probing helpers
- extend configuration surface and telemetry helpers to expose ATX, airtime, and guard tuning knobs

## Testing
- `PROTOC=/tmp/protoc-wrapper.sh cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68f7349448a08332a6b9ffcc4af56b90