### PR TITLE
Support ATX metrics in mesh heartbeat payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "chirpstack_api"
-version = "4.13.0"
+version = "4.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cfc11003ad9d3d763dd5ad3753cd31baf211f52e7c326b266e3d32fdf0fe23"
+checksum = "7fc488587b4a39165e86b781c7a2824fe387d38688c652b0be85b2809e4c6582"
 dependencies = [
  "hex",
  "pbjson-build",
@@ -210,6 +210,7 @@ dependencies = [
  "prost-types",
  "rand 0.9.2",
  "tonic-build",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -790,15 +791,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -998,12 +990,12 @@ dependencies = [
 
 [[package]]
 name = "pbjson-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+checksum = "af22d08a625a2213a78dbb0ffa253318c5c79ce3133d32d296655a7bdfb02095"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools",
  "prost",
  "prost-types",
 ]
@@ -1116,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1126,12 +1118,12 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -1146,12 +1138,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -1159,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
@@ -1736,9 +1728,21 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1746,6 +1750,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
     "usage",
     "derive",
   ] }
-  chirpstack_api = { version = "4.13", default-features = false }
+  chirpstack_api = { version = "4.15", default-features = false }
   lrwn_filters = { version = "4.12", features = ["serde"] }
   log = "0.4"
   simple_logger = "5.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,77 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(mesh_event_has_atx_metrics)");
+    if detect_mesh_atx_metrics().unwrap_or(false) {
+        println!("cargo:rustc-cfg=mesh_event_has_atx_metrics");
+    }
+}
+
+fn detect_mesh_atx_metrics() -> std::io::Result<bool> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let lock_path = manifest_dir.join("Cargo.lock");
+    let lock = fs::read_to_string(lock_path)?;
+
+    let mut capture = false;
+    let mut version: Option<String> = None;
+    for line in lock.lines() {
+        let trimmed = line.trim();
+        if trimmed == "name = \"chirpstack_api\"" {
+            capture = true;
+            continue;
+        }
+        if capture && trimmed.starts_with("version = ") {
+            let v = trimmed
+                .trim_start_matches("version = ")
+                .trim_matches('"')
+                .to_string();
+            version = Some(v);
+            break;
+        }
+        if trimmed.starts_with("name = ") {
+            capture = false;
+        }
+    }
+
+    let version = match version {
+        Some(v) => v,
+        None => return Ok(false),
+    };
+
+    let cargo_home = env::var("CARGO_HOME").unwrap_or_else(|_| {
+        env::var("HOME")
+            .map(|home| format!("{}/.cargo", home))
+            .unwrap_or_else(|_| ".cargo".into())
+    });
+
+    let registry_src = PathBuf::from(cargo_home).join("registry/src");
+    if !registry_src.exists() {
+        return Ok(false);
+    }
+
+    let mut proto_path: Option<PathBuf> = None;
+    for entry in fs::read_dir(registry_src)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let candidate = path
+            .join(format!("chirpstack_api-{}", version))
+            .join("proto/chirpstack/gw/gw.proto");
+        if candidate.exists() {
+            proto_path = Some(candidate);
+            break;
+        }
+    }
+
+    let proto_path = match proto_path {
+        Some(p) => p,
+        None => return Ok(false),
+    };
+
+    let proto = fs::read_to_string(proto_path)?;
+    Ok(proto.contains("advertised_atx_path_cost") || proto.contains("advertised_atx_depth"))
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -15,6 +15,7 @@ use crate::config::{self, Configuration};
 use crate::helpers;
 use crate::mesh::get_mesh_frequency;
 use crate::packets;
+use crate::routing;
 
 static COMMANDS: OnceCell<HashMap<u8, Vec<String>>> = OnceCell::const_new();
 
@@ -83,8 +84,13 @@ pub async fn setup(conf: &Configuration) -> Result<()> {
 
 pub async fn report_heartbeat() -> Result<()> {
     info!("Sending heartbeat event");
+    let selector = routing::selector().await;
+    let route = selector.local_route().await.unwrap_or_default();
+
     send_events(vec![packets::Event::Heartbeat(packets::HeartbeatPayload {
         relay_path: vec![],
+        atx_path_cost: route.path_cost,
+        atx_depth: route.depth,
     })])
     .await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub mod logging;
 pub mod mesh;
 pub mod packets;
 pub mod proxy;
+pub mod routing;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -18,7 +18,7 @@ use crate::{
         self, DownlinkMetadata, Event, MeshPacket, Payload, PayloadType, UplinkMetadata,
         UplinkPayload, MHDR,
     },
-    proxy,
+    proxy, routing,
 };
 
 static CTX_PREFIX: [u8; 3] = [1, 2, 3];
@@ -216,9 +216,10 @@ async fn proxy_uplink_mesh_packet(pl: &gw::UplinkFrame, packet: MeshPacket) -> R
         rx_info
             .metadata
             .insert("relay_id".to_string(), hex::encode(mesh_pl.relay_id));
-        rx_info
-            .metadata
-            .insert("uplink_id".to_string(), mesh_pl.metadata.uplink_id.to_string());
+        rx_info.metadata.insert(
+            "uplink_id".to_string(),
+            mesh_pl.metadata.uplink_id.to_string(),
+        );
 
         // Calculate mesh delay (in ms) and add to metadata.
         let delay = helpers::ms_since_midnight().saturating_sub(mesh_pl.timestamp);
@@ -270,6 +271,15 @@ async fn proxy_event_mesh_packet(pl: &gw::UplinkFrame, packet: MeshPacket) -> Re
         packet
     );
 
+    let selector = routing::selector().await;
+    for event in &mesh_pl.events {
+        if let Event::Heartbeat(hb) = event {
+            selector
+                .on_beacon(mesh_pl.relay_id, hb.atx_path_cost, hb.atx_depth)
+                .await;
+        }
+    }
+
     let event = gw::Event {
         event: Some(gw::event::Event::Mesh(gw::MeshEvent {
             gateway_id: hex::encode(backend::get_gateway_id().await?),
@@ -280,19 +290,9 @@ async fn proxy_event_mesh_packet(pl: &gw::UplinkFrame, packet: MeshPacket) -> Re
                 .iter()
                 .map(|e| gw::MeshEventItem {
                     event: Some(match e {
-                        Event::Heartbeat(v) => {
-                            gw::mesh_event_item::Event::Heartbeat(gw::MeshEventHeartbeat {
-                                relay_path: v
-                                    .relay_path
-                                    .iter()
-                                    .map(|v| gw::MeshEventHeartbeatRelayPath {
-                                        relay_id: hex::encode(v.relay_id),
-                                        rssi: v.rssi.into(),
-                                        snr: v.snr.into(),
-                                    })
-                                    .collect(),
-                            })
-                        }
+                        Event::Heartbeat(v) => gw::mesh_event_item::Event::Heartbeat(
+                            mesh_event_heartbeat_from_payload(v),
+                        ),
                         Event::Proprietary(v) => {
                             gw::mesh_event_item::Event::Proprietary(gw::MeshEventProprietary {
                                 event_type: v.0.into(),
@@ -318,6 +318,9 @@ async fn relay_mesh_packet(pl: &gw::UplinkFrame, mut packet: MeshPacket) -> Resu
         .rx_info
         .as_ref()
         .ok_or_else(|| anyhow!("rx_info is None"))?;
+
+    let selector = routing::selector().await;
+    let local_route = selector.local_route().await.unwrap_or_default();
 
     match &mut packet.payload {
         packets::Payload::Uplink(pl) => {
@@ -378,6 +381,8 @@ async fn relay_mesh_packet(pl: &gw::UplinkFrame, mut packet: MeshPacket) -> Resu
             for event in &mut pl.events {
                 // Add our Relay ID to the path in case of heartbeat event.
                 if let Event::Heartbeat(v) = event {
+                    v.atx_path_cost = local_route.path_cost;
+                    v.atx_depth = local_route.depth;
                     v.relay_path.push(packets::RelayPath {
                         relay_id,
                         rssi: rx_info.rssi as i16,
@@ -643,6 +648,42 @@ async fn relay_downlink_lora_packet(pl: &gw::DownlinkFrame) -> Result<gw::Downli
         items: tx_ack_items,
         ..Default::default()
     })
+}
+
+#[cfg(mesh_event_has_atx_metrics)]
+fn mesh_event_heartbeat_from_payload(
+    payload: &packets::HeartbeatPayload,
+) -> gw::MeshEventHeartbeat {
+    gw::MeshEventHeartbeat {
+        advertised_atx_path_cost: payload.atx_path_cost,
+        advertised_atx_depth: payload.atx_depth.into(),
+        relay_path: payload
+            .relay_path
+            .iter()
+            .map(|v| gw::MeshEventHeartbeatRelayPath {
+                relay_id: hex::encode(v.relay_id),
+                rssi: v.rssi.into(),
+                snr: v.snr.into(),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(not(mesh_event_has_atx_metrics))]
+fn mesh_event_heartbeat_from_payload(
+    payload: &packets::HeartbeatPayload,
+) -> gw::MeshEventHeartbeat {
+    gw::MeshEventHeartbeat {
+        relay_path: payload
+            .relay_path
+            .iter()
+            .map(|v| gw::MeshEventHeartbeatRelayPath {
+                relay_id: hex::encode(v.relay_id),
+                rssi: v.rssi.into(),
+                snr: v.snr.into(),
+            })
+            .collect(),
+    }
 }
 
 pub fn get_mesh_frequency(conf: &Configuration) -> Result<u32> {

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -628,10 +628,16 @@ impl Event {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HeartbeatPayload {
     pub relay_path: Vec<RelayPath>,
+    pub atx_path_cost: u32,
+    pub atx_depth: u16,
 }
 
 impl HeartbeatPayload {
     pub fn from_slice(b: &[u8]) -> Result<Self> {
+        if b.len() >= 6 && b[0] == 0x01 && b[1] == 4 {
+            return HeartbeatPayload::from_tlv(b);
+        }
+
         if b.len() % 6 != 0 {
             return Err(anyhow!("Invalid amount of Relay path bytes"));
         }
@@ -645,14 +651,101 @@ impl HeartbeatPayload {
             })
             .collect();
 
-        Ok(HeartbeatPayload { relay_path })
+        Ok(HeartbeatPayload {
+            relay_path,
+            atx_path_cost: 0,
+            atx_depth: 0,
+        })
+    }
+
+    fn from_tlv(b: &[u8]) -> Result<Self> {
+        let mut atx_path_cost = 0;
+        let mut atx_depth = 0;
+        let mut relay_path = Vec::new();
+        let mut i = 0;
+
+        while i < b.len() {
+            if i + 2 > b.len() {
+                return Err(anyhow!("Truncated TLV"));
+            }
+
+            let t = b[i];
+            let l = b[i + 1] as usize;
+            i += 2;
+
+            if i + l > b.len() {
+                return Err(anyhow!("Invalid TLV length"));
+            }
+
+            match t {
+                0x01 => {
+                    if l != 4 {
+                        return Err(anyhow!("Invalid ATX path cost length"));
+                    }
+                    atx_path_cost = u32::from_be_bytes([b[i], b[i + 1], b[i + 2], b[i + 3]]);
+                }
+                0x02 => {
+                    if l != 2 {
+                        return Err(anyhow!("Invalid ATX depth length"));
+                    }
+                    atx_depth = u16::from_be_bytes([b[i], b[i + 1]]);
+                }
+                0x03 => {
+                    if l % 6 != 0 {
+                        return Err(anyhow!("Invalid relay path length"));
+                    }
+
+                    relay_path = b[i..i + l]
+                        .chunks(6)
+                        .map(|v| {
+                            let mut b: [u8; 6] = [0; 6];
+                            b.copy_from_slice(v);
+                            RelayPath::from_bytes(b)
+                        })
+                        .collect();
+                }
+                _ => {
+                    return Err(anyhow!("Unknown Heartbeat TLV type"));
+                }
+            }
+
+            i += l;
+        }
+
+        Ok(HeartbeatPayload {
+            relay_path,
+            atx_path_cost,
+            atx_depth,
+        })
     }
 
     pub fn to_vec(&self) -> Result<Vec<u8>> {
-        let mut b = Vec::with_capacity(self.relay_path.len() * 6);
+        let mut relay_path_bytes = Vec::with_capacity(self.relay_path.len());
         for relay_path in &self.relay_path {
-            b.extend_from_slice(&relay_path.to_bytes()?);
+            relay_path_bytes.push(relay_path.to_bytes()?);
         }
+
+        let relay_path_len = relay_path_bytes.len() * 6;
+        if relay_path_len > u8::MAX as usize {
+            return Err(anyhow!("Relay path exceeds maximum TLV length"));
+        }
+
+        let mut b =
+            Vec::with_capacity(2 + 4 + 2 + relay_path_len + if relay_path_len > 0 { 2 } else { 0 });
+
+        b.extend_from_slice(&[0x01, 4]);
+        b.extend_from_slice(&self.atx_path_cost.to_be_bytes());
+
+        b.extend_from_slice(&[0x02, 2]);
+        b.extend_from_slice(&self.atx_depth.to_be_bytes());
+
+        if relay_path_len > 0 {
+            b.extend_from_slice(&[0x03, relay_path_len as u8]);
+            for chunk in relay_path_bytes {
+                b.extend_from_slice(&chunk);
+            }
+        }
+
         Ok(b)
     }
 }
@@ -1216,8 +1309,7 @@ mod test {
     #[test]
     fn test_uplink_payload_from_vec() {
         let b = vec![
-            0x40, 0x03, 0x78, 0x34, 0x40, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03,
-            0x04, 0x05,
+            0x40, 0x03, 0x78, 0x34, 0x40, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
         ];
         let up_pl = UplinkPayload::from_slice(&b).unwrap();
         assert_eq!(
@@ -1254,8 +1346,7 @@ mod test {
         let b = up_pl.to_vec().unwrap();
         assert_eq!(
             vec![
-                0x40, 0x03, 0x78, 0x34, 0x40, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02,
-                0x03, 0x04, 0x05,
+                0x40, 0x03, 0x78, 0x34, 0x40, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
             ],
             b
         );
@@ -1429,45 +1520,14 @@ mod test {
 
     #[test]
     fn test_event_heartbeat_payload_from_slice() {
-        let b = vec![
-            59, 154, 202, 0, 1, 2, 3, 4, 0, 12, 5, 6, 7, 8, 120, 52, 9, 10, 11, 12, 120, 52,
-        ];
-        let mut event_pl = EventPayload::from_slice(&b).unwrap();
-        event_pl.decode().unwrap();
-
-        assert_eq!(
-            EventPayload {
-                timestamp: UNIX_EPOCH
-                    .checked_add(Duration::from_secs(1_000_000_000))
-                    .unwrap(),
-                relay_id: [1, 2, 3, 4],
-                events: vec![Event::Heartbeat(HeartbeatPayload {
-                    relay_path: vec![
-                        RelayPath {
-                            relay_id: [5, 6, 7, 8],
-                            rssi: -120,
-                            snr: -12,
-                        },
-                        RelayPath {
-                            relay_id: [9, 10, 11, 12],
-                            rssi: -120,
-                            snr: -12,
-                        },
-                    ]
-                }),],
-            },
-            event_pl,
-        );
-    }
-
-    #[test]
-    fn test_heartbeat_payload_to_vec() {
         let event_pl = EventPayload {
             timestamp: UNIX_EPOCH
                 .checked_add(Duration::from_secs(1_000_000_000))
                 .unwrap(),
             relay_id: [1, 2, 3, 4],
             events: vec![Event::Heartbeat(HeartbeatPayload {
+                atx_path_cost: 513,
+                atx_depth: 12,
                 relay_path: vec![
                     RelayPath {
                         relay_id: [5, 6, 7, 8],
@@ -1483,9 +1543,67 @@ mod test {
             })],
         };
         let b = event_pl.to_vec().unwrap();
+        let mut decoded = EventPayload::from_slice(&b).unwrap();
+        decoded.decode().unwrap();
+        assert_eq!(event_pl, decoded);
+    }
+
+    #[test]
+    fn test_heartbeat_payload_to_vec() {
+        let hb = HeartbeatPayload {
+            atx_path_cost: 513,
+            atx_depth: 12,
+            relay_path: vec![
+                RelayPath {
+                    relay_id: [5, 6, 7, 8],
+                    rssi: -120,
+                    snr: -12,
+                },
+                RelayPath {
+                    relay_id: [9, 10, 11, 12],
+                    rssi: -120,
+                    snr: -12,
+                },
+            ],
+        };
+
         assert_eq!(
-            vec![59, 154, 202, 0, 1, 2, 3, 4, 0, 12, 5, 6, 7, 8, 120, 52, 9, 10, 11, 12, 120, 52],
-            b
+            vec![
+                1, 4, 0, 0, 2, 1, // cost TLV
+                2, 2, 0, 12, // depth TLV
+                3, 12, // relay path TLV header
+                5, 6, 7, 8, 120, 52, // first path entry
+                9, 10, 11, 12, 120, 52, // second path entry
+            ],
+            hb.to_vec().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_heartbeat_payload_from_slice_legacy() {
+        let legacy_bytes = vec![
+            5, 6, 7, 8, 120, 52, // first entry
+            9, 10, 11, 12, 120, 52, // second entry
+        ];
+
+        assert_eq!(
+            HeartbeatPayload {
+                atx_path_cost: 0,
+                atx_depth: 0,
+                relay_path: vec![
+                    RelayPath {
+                        relay_id: [5, 6, 7, 8],
+                        rssi: -120,
+                        snr: -12,
+                    },
+                    RelayPath {
+                        relay_id: [9, 10, 11, 12],
+                        rssi: -120,
+                        snr: -12,
+                    },
+                ],
+            },
+            HeartbeatPayload::from_slice(&legacy_bytes).unwrap()
         );
     }
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{OnceCell, RwLock};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RouteEntry {
+    pub path_cost: u32,
+    pub depth: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct NeighborMetrics {
+    pub path_cost: u32,
+    pub depth: u16,
+}
+
+#[derive(Debug, Default)]
+pub struct TrickleRouteSelector {
+    local_route: RwLock<Option<RouteEntry>>,
+    neighbors: RwLock<HashMap<[u8; 4], NeighborMetrics>>,
+}
+
+impl TrickleRouteSelector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn set_local_route(&self, entry: Option<RouteEntry>) {
+        let mut guard = self.local_route.write().await;
+        *guard = entry;
+    }
+
+    pub async fn local_route(&self) -> Option<RouteEntry> {
+        *self.local_route.read().await
+    }
+
+    pub async fn on_beacon(&self, relay_id: [u8; 4], path_cost: u32, depth: u16) {
+        let mut guard = self.neighbors.write().await;
+        guard.insert(relay_id, NeighborMetrics { path_cost, depth });
+    }
+
+    pub async fn neighbor_metrics(&self, relay_id: &[u8; 4]) -> Option<NeighborMetrics> {
+        self.neighbors.read().await.get(relay_id).copied()
+    }
+
+    pub async fn reset(&self) {
+        self.local_route.write().await.take();
+        self.neighbors.write().await.clear();
+    }
+}
+
+static ROUTE_SELECTOR: OnceCell<Arc<TrickleRouteSelector>> = OnceCell::const_new();
+
+pub async fn selector() -> Arc<TrickleRouteSelector> {
+    ROUTE_SELECTOR
+        .get_or_init(|| async { Arc::new(TrickleRouteSelector::default()) })
+        .await
+        .clone()
+}
+
+pub async fn reset() {
+    if let Some(selector) = ROUTE_SELECTOR.get() {
+        selector.reset().await;
+    }
+}

--- a/tests/border_gateway_mesh_event_heartbeat.rs
+++ b/tests/border_gateway_mesh_event_heartbeat.rs
@@ -8,7 +8,7 @@ use chirpstack_api::prost::Message;
 use zeromq::{SocketRecv, SocketSend};
 
 use chirpstack_gateway_mesh::aes128::{get_encryption_key, get_signing_key, Aes128Key};
-use chirpstack_gateway_mesh::packets;
+use chirpstack_gateway_mesh::{packets, routing};
 
 mod common;
 
@@ -19,6 +19,7 @@ mod common;
 #[tokio::test]
 async fn test_border_gateway_mesh_heartbeat() {
     common::setup(true).await;
+    routing::reset().await;
 
     let mut packet = packets::MeshPacket {
         mhdr: packets::MHDR {
@@ -29,6 +30,8 @@ async fn test_border_gateway_mesh_heartbeat() {
             relay_id: [2, 2, 2, 2],
             timestamp: UNIX_EPOCH,
             events: vec![packets::Event::Heartbeat(packets::HeartbeatPayload {
+                atx_path_cost: 1_234,
+                atx_depth: 9,
                 relay_path: vec![
                     packets::RelayPath {
                         relay_id: [1, 2, 3, 4],
@@ -125,4 +128,12 @@ async fn test_border_gateway_mesh_heartbeat() {
         },
         mesh_event
     );
+
+    let selector = routing::selector().await;
+    let metrics = selector
+        .neighbor_metrics(&[2, 2, 2, 2])
+        .await
+        .expect("neighbor metrics recorded");
+    assert_eq!(metrics.path_cost, 1_234);
+    assert_eq!(metrics.depth, 9);
 }

--- a/tests/relay_gateway_mesh_event_heartbeat.rs
+++ b/tests/relay_gateway_mesh_event_heartbeat.rs
@@ -5,7 +5,7 @@ extern crate anyhow;
 
 use chirpstack_api::gw;
 use chirpstack_api::prost::Message;
-use chirpstack_gateway_mesh::packets;
+use chirpstack_gateway_mesh::{packets, routing};
 use zeromq::SocketRecv;
 
 use chirpstack_gateway_mesh::aes128::{get_encryption_key, Aes128Key};
@@ -19,6 +19,15 @@ mod common;
 #[tokio::test]
 async fn test_relay_gateway_mesh_event_heartbeat() {
     common::setup(false).await;
+    routing::reset().await;
+    let selector = routing::selector().await;
+    selector
+        .set_local_route(Some(routing::RouteEntry {
+            path_cost: 321,
+            depth: 7,
+        }))
+        .await;
+
     let _ = events::report_heartbeat().await;
 
     // We expect the heartbeat to be received by the mesh concentratord as
@@ -70,7 +79,9 @@ async fn test_relay_gateway_mesh_event_heartbeat() {
                 relay_id: [2, 2, 2, 2],
                 timestamp: UNIX_EPOCH,
                 events: vec![packets::Event::Heartbeat(packets::HeartbeatPayload {
-                    relay_path: vec![]
+                    atx_path_cost: 321,
+                    atx_depth: 7,
+                    relay_path: vec![],
                 }),],
             }),
             mic: None,

--- a/tests/relay_gateway_relay_mesh_event.rs
+++ b/tests/relay_gateway_relay_mesh_event.rs
@@ -30,6 +30,8 @@ async fn test_relay_gateway_relay_mesh_heartbeat() {
             relay_id: [1, 2, 3, 4],
             timestamp: UNIX_EPOCH,
             events: vec![packets::Event::Heartbeat(packets::HeartbeatPayload {
+                atx_path_cost: 0,
+                atx_depth: 0,
                 relay_path: vec![],
             })],
         }),


### PR DESCRIPTION
## Summary
- bump `chirpstack_api` to 4.15 and add a build script that gates ATX heartbeat support on the proto definitions
- extend the mesh heartbeat TLV to encode advertised ATX path cost and depth, and surface those values through the new routing selector helper
- propagate the ATX metrics when sending, relaying, and proxying heartbeat events so the routing selector learns neighbours
- update and add tests that cover the new TLV format and routing integration

## Testing
- cargo check
- cargo test --lib heartbeat_payload
- cargo test test_relay_gateway_mesh_event_heartbeat -- --test-threads=1
- cargo test test_border_gateway_mesh_heartbeat -- --test-threads=1

------
https://chatgpt.com/codex/tasks/task_e_68f73f2e62bc8332900303f3fee214db